### PR TITLE
Formatting changes suggested by C++ Core Guidelines

### DIFF
--- a/daemon/.clang-format
+++ b/daemon/.clang-format
@@ -1,1 +1,6 @@
 BasedOnStyle: Google
+
+Language: Cpp
+# Force pointers to the type for C++.
+DerivePointerAlignment: false
+PointerAlignment: Left

--- a/daemon/.vscode/c_cpp_properties.json
+++ b/daemon/.vscode/c_cpp_properties.json
@@ -1,35 +1,32 @@
 {
-    "configurations": [
-        {
-            "name": "Mac",
-            "includePath": [
-                "${workspaceFolder}/**",
-                "${workspaceFolder}/dependencies/readerwriterqueue",
-                "/usr/local/wpilib/include/ntcore",
-                "/usr/local/wpilib/include/wpiutil",
-                "/usr/local/wpilib/include/cscore",
-                "/usr/local/Cellar/spdlog/1.7.0/include"
-            ],
-            "defines": [],
-            "macFrameworkPath": [],
-            "compilerPath": "/usr/bin/clang",
-            "cStandard": "c11",
-            "cppStandard": "c++17",
-            "intelliSenseMode": "${default}",
-            "compileCommands": "${workspaceFolder}/build/compile_commands.json",
-            "configurationProvider": "ms-vscode.cmake-tools"
-        },
-        {
-            "name": "Linux",
-            "includePath": [
-                "${workspaceFolder}/**"
-            ],
-            "defines": [],
-            "compilerPath": "/usr/bin/g++",
-            "cStandard": "c11",
-            "cppStandard": "c++17",
-            "intelliSenseMode": "gcc-x64"
-        }
-    ],
-    "version": 4
+  "configurations": [
+    {
+      "name": "Mac",
+      "includePath": [
+        "${workspaceFolder}/**",
+        "/usr/local/wpilib/include/ntcore",
+        "/usr/local/wpilib/include/wpiutil",
+        "/usr/local/wpilib/include/cscore",
+        "/usr/local/Cellar/spdlog/1.7.0/include"
+      ],
+      "defines": [],
+      "macFrameworkPath": [],
+      "compilerPath": "/usr/bin/clang",
+      "cStandard": "c11",
+      "cppStandard": "c++17",
+      "intelliSenseMode": "${default}",
+      "compileCommands": "${workspaceFolder}/build/compile_commands.json",
+      "configurationProvider": "ms-vscode.cmake-tools"
+    },
+    {
+      "name": "Linux",
+      "includePath": ["${workspaceFolder}/**"],
+      "defines": [],
+      "compilerPath": "/usr/bin/g++",
+      "cStandard": "c11",
+      "cppStandard": "c++17",
+      "intelliSenseMode": "gcc-x64"
+    }
+  ],
+  "version": 4
 }

--- a/daemon/src/config/capture_config.cpp
+++ b/daemon/src/config/capture_config.cpp
@@ -15,15 +15,6 @@ static const std::string kGainRange = "1 1";
 static const std::array<int, 2> kExposureRange{13000, 8333333};
 }  // namespace
 
-const char* CaptureConfig::kTypeKey{"type"};
-const char* CaptureConfig::kCaptureWidthKey{"cw"};
-const char* CaptureConfig::kCaptureHeightKey{"ch"};
-const char* CaptureConfig::kOutputWidthKey{"ow"};
-const char* CaptureConfig::kOutputHeightKey{"oh"};
-const char* CaptureConfig::kFrameRateKey{"fps"};
-const char* CaptureConfig::kFlipModeKey{"flip"};
-const char* CaptureConfig::kExposureKey{"exp"};
-
 CaptureConfig::CaptureConfig(Type type, int capture_width, int capture_height,
                              int output_width, int output_height,
                              int frame_rate, int flip_mode, double exposure)

--- a/daemon/src/config/capture_config.cpp
+++ b/daemon/src/config/capture_config.cpp
@@ -15,14 +15,14 @@ static const std::string kGainRange = "1 1";
 static const std::array<int, 2> kExposureRange{13000, 8333333};
 }  // namespace
 
-char const* CaptureConfig::kTypeKey{"type"};
-char const* CaptureConfig::kCaptureWidthKey{"cw"};
-char const* CaptureConfig::kCaptureHeightKey{"ch"};
-char const* CaptureConfig::kOutputWidthKey{"ow"};
-char const* CaptureConfig::kOutputHeightKey{"oh"};
-char const* CaptureConfig::kFrameRateKey{"fps"};
-char const* CaptureConfig::kFlipModeKey{"flip"};
-char const* CaptureConfig::kExposureKey{"exp"};
+const char* CaptureConfig::kTypeKey{"type"};
+const char* CaptureConfig::kCaptureWidthKey{"cw"};
+const char* CaptureConfig::kCaptureHeightKey{"ch"};
+const char* CaptureConfig::kOutputWidthKey{"ow"};
+const char* CaptureConfig::kOutputHeightKey{"oh"};
+const char* CaptureConfig::kFrameRateKey{"fps"};
+const char* CaptureConfig::kFlipModeKey{"flip"};
+const char* CaptureConfig::kExposureKey{"exp"};
 
 CaptureConfig::CaptureConfig(Type type, int capture_width, int capture_height,
                              int output_width, int output_height,

--- a/daemon/src/config/capture_config.h
+++ b/daemon/src/config/capture_config.h
@@ -14,14 +14,14 @@ namespace deadeye {
 struct CaptureConfig {
   enum class Type { autosrc, jetson, osx, test };
 
-  static const char* kTypeKey;
-  static const char* kCaptureWidthKey;
-  static const char* kCaptureHeightKey;
-  static const char* kOutputWidthKey;
-  static const char* kOutputHeightKey;
-  static const char* kFrameRateKey;
-  static const char* kFlipModeKey;
-  static const char* kExposureKey;
+  static constexpr auto kTypeKey = "type";
+  static constexpr auto kCaptureWidthKey = "cw";
+  static constexpr auto kCaptureHeightKey = "ch";
+  static constexpr auto kOutputWidthKey = "ow";
+  static constexpr auto kOutputHeightKey = "oh";
+  static constexpr auto kFrameRateKey = "fps";
+  static constexpr auto kFlipModeKey = "flip";
+  static constexpr auto kExposureKey = "exp";
 
   Type type = Type::test;
   int capture_width = 0;

--- a/daemon/src/config/capture_config.h
+++ b/daemon/src/config/capture_config.h
@@ -2,6 +2,7 @@
 #include <fmt/core.h>
 #include <networktables/NetworkTableValue.h>
 #include <spdlog/fmt/ostr.h>
+
 #include <iostream>
 #include <nlohmann/json.hpp>
 #include <opencv2/core/types.hpp>
@@ -13,14 +14,14 @@ namespace deadeye {
 struct CaptureConfig {
   enum class Type { autosrc, jetson, osx, test };
 
-  static char const* kTypeKey;
-  static char const* kCaptureWidthKey;
-  static char const* kCaptureHeightKey;
-  static char const* kOutputWidthKey;
-  static char const* kOutputHeightKey;
-  static char const* kFrameRateKey;
-  static char const* kFlipModeKey;
-  static char const* kExposureKey;
+  static const char* kTypeKey;
+  static const char* kCaptureWidthKey;
+  static const char* kCaptureHeightKey;
+  static const char* kOutputWidthKey;
+  static const char* kOutputHeightKey;
+  static const char* kFrameRateKey;
+  static const char* kFlipModeKey;
+  static const char* kExposureKey;
 
   Type type = Type::test;
   int capture_width = 0;
@@ -66,7 +67,7 @@ struct CaptureConfig {
   cv::Size OutputSize() const;
 
   template <typename OStream>
-  friend OStream& operator<<(OStream& os, CaptureConfig const& cc) {
+  friend OStream& operator<<(OStream& os, const CaptureConfig& cc) {
     std::string output = fmt::format(
         "CaptureConfig<type={}, cw={}, ch={}, ow={}, oh={}, fps={}, flip={}, "
         "exp={}>",
@@ -80,7 +81,7 @@ struct CaptureConfig {
 void to_json(json& j, const CaptureConfig& cc);
 void from_json(const json& j, CaptureConfig& cc);
 
-inline bool operator==(CaptureConfig const& lhs, CaptureConfig const& rhs) {
+inline bool operator==(const CaptureConfig& lhs, const CaptureConfig& rhs) {
   return lhs.capture_width == rhs.capture_width &&
          lhs.capture_height == rhs.capture_height &&
          lhs.output_width == rhs.output_width &&
@@ -89,7 +90,7 @@ inline bool operator==(CaptureConfig const& lhs, CaptureConfig const& rhs) {
          lhs.exposure == rhs.exposure;
 }
 
-inline bool operator!=(CaptureConfig const& lhs, CaptureConfig const& rhs) {
+inline bool operator!=(const CaptureConfig& lhs, const CaptureConfig& rhs) {
   return !(lhs == rhs);
 }
 

--- a/daemon/src/config/filter_config.cpp
+++ b/daemon/src/config/filter_config.cpp
@@ -3,9 +3,9 @@
 using namespace deadeye;
 using json = nlohmann::json;
 
-char const* FilterConfig::kAreaKey{"area"};
-char const* FilterConfig::kSolidityKey{"solidity"};
-char const* FilterConfig::kAspectKey{"aspect"};
+const char* FilterConfig::kAreaKey{"area"};
+const char* FilterConfig::kSolidityKey{"solidity"};
+const char* FilterConfig::kAspectKey{"aspect"};
 
 FilterConfig::FilterConfig(filter_t area, filter_t solidity, filter_t aspect)
     : area(area), solidity(solidity), aspect(aspect) {

--- a/daemon/src/config/filter_config.cpp
+++ b/daemon/src/config/filter_config.cpp
@@ -3,10 +3,6 @@
 using namespace deadeye;
 using json = nlohmann::json;
 
-const char* FilterConfig::kAreaKey{"area"};
-const char* FilterConfig::kSolidityKey{"solidity"};
-const char* FilterConfig::kAspectKey{"aspect"};
-
 FilterConfig::FilterConfig(filter_t area, filter_t solidity, filter_t aspect)
     : area(area), solidity(solidity), aspect(aspect) {
   area_enabled = area[0] != kAreaMin || area[1] != kAreaMax;

--- a/daemon/src/config/filter_config.h
+++ b/daemon/src/config/filter_config.h
@@ -16,9 +16,9 @@ static constexpr double kAspectMax = 20.0;
 }  // namespace
 
 struct FilterConfig {
-  static char const* kAreaKey;
-  static char const* kSolidityKey;
-  static char const* kAspectKey;
+  static const char* kAreaKey;
+  static const char* kSolidityKey;
+  static const char* kAspectKey;
 
   using filter_t = std::array<double, 2>;
 
@@ -47,12 +47,12 @@ struct FilterConfig {
 void to_json(json& j, const FilterConfig& l);
 void from_json(const json& j, FilterConfig& l);
 
-inline bool operator==(FilterConfig const& lhs, FilterConfig const& rhs) {
+inline bool operator==(const FilterConfig& lhs, const FilterConfig& rhs) {
   return lhs.area == rhs.area && lhs.solidity == rhs.solidity &&
          lhs.aspect == rhs.aspect;
 }
 
-inline bool operator!=(FilterConfig const& lhs, FilterConfig const& rhs) {
+inline bool operator!=(const FilterConfig& lhs, const FilterConfig& rhs) {
   return !(lhs == rhs);
 }
 

--- a/daemon/src/config/filter_config.h
+++ b/daemon/src/config/filter_config.h
@@ -16,9 +16,9 @@ static constexpr double kAspectMax = 20.0;
 }  // namespace
 
 struct FilterConfig {
-  static const char* kAreaKey;
-  static const char* kSolidityKey;
-  static const char* kAspectKey;
+  static constexpr auto kAreaKey = "area";
+  static constexpr auto kSolidityKey = "solidity";
+  static constexpr auto kAspectKey = "aspect";
 
   using filter_t = std::array<double, 2>;
 

--- a/daemon/src/config/link_config.cpp
+++ b/daemon/src/config/link_config.cpp
@@ -3,9 +3,9 @@
 using namespace deadeye;
 using json = nlohmann::json;
 
-char const* LinkConfig::kAddressKey{"address"};
-char const* LinkConfig::kPortKey{"port"};
-char const* LinkConfig::kEnabledKey{"enabled"};
+const char* LinkConfig::kAddressKey{"address"};
+const char* LinkConfig::kPortKey{"port"};
+const char* LinkConfig::kEnabledKey{"enabled"};
 
 LinkConfig::LinkConfig() {}
 

--- a/daemon/src/config/link_config.cpp
+++ b/daemon/src/config/link_config.cpp
@@ -3,10 +3,6 @@
 using namespace deadeye;
 using json = nlohmann::json;
 
-const char* LinkConfig::kAddressKey{"address"};
-const char* LinkConfig::kPortKey{"port"};
-const char* LinkConfig::kEnabledKey{"enabled"};
-
 LinkConfig::LinkConfig() {}
 
 LinkConfig::LinkConfig(std::string address, int port, bool enabled)

--- a/daemon/src/config/link_config.h
+++ b/daemon/src/config/link_config.h
@@ -9,9 +9,9 @@ using json = nlohmann::json;
 namespace deadeye {
 
 struct LinkConfig {
-  static const char* kAddressKey;
-  static const char* kPortKey;
-  static const char* kEnabledKey;
+  static constexpr auto kAddressKey = "address";
+  static constexpr auto kPortKey = "port";
+  static constexpr auto kEnabledKey = "enabled";
 
   std::string address;
   int port;

--- a/daemon/src/config/link_config.h
+++ b/daemon/src/config/link_config.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <networktables/NetworkTableValue.h>
+
 #include <nlohmann/json.hpp>
 #include <string>
 
@@ -8,9 +9,9 @@ using json = nlohmann::json;
 namespace deadeye {
 
 struct LinkConfig {
-  static char const* kAddressKey;
-  static char const* kPortKey;
-  static char const* kEnabledKey;
+  static const char* kAddressKey;
+  static const char* kPortKey;
+  static const char* kEnabledKey;
 
   std::string address;
   int port;
@@ -35,12 +36,12 @@ struct LinkConfig {
 void to_json(json& j, const LinkConfig& l);
 void from_json(const json& j, LinkConfig& l);
 
-inline bool operator==(LinkConfig const& lhs, LinkConfig const& rhs) {
+inline bool operator==(const LinkConfig& lhs, const LinkConfig& rhs) {
   return lhs.address == rhs.address && lhs.port == rhs.port &&
          lhs.enabled == rhs.enabled;
 }
 
-inline bool operator!=(LinkConfig const& lhs, LinkConfig const& rhs) {
+inline bool operator!=(const LinkConfig& lhs, const LinkConfig& rhs) {
   return !(lhs == rhs);
 }
 

--- a/daemon/src/config/log_config.cpp
+++ b/daemon/src/config/log_config.cpp
@@ -3,10 +3,10 @@
 using namespace deadeye;
 using json = nlohmann::json;
 
-char const* LogConfig::kPathKey{"path"};
-char const* LogConfig::kMountKey{"mount"};
-char const* LogConfig::kFpsKey{"fps"};
-char const* LogConfig::kDefaultPath{"/var/opt/deadeye"};
+const char* LogConfig::kPathKey{"path"};
+const char* LogConfig::kMountKey{"mount"};
+const char* LogConfig::kFpsKey{"fps"};
+const char* LogConfig::kDefaultPath{"/var/opt/deadeye"};
 
 LogConfig::LogConfig(std::string path, int fps, bool mount)
     : path(path), fps(fps), mount(mount) {}

--- a/daemon/src/config/log_config.cpp
+++ b/daemon/src/config/log_config.cpp
@@ -3,11 +3,6 @@
 using namespace deadeye;
 using json = nlohmann::json;
 
-const char* LogConfig::kPathKey{"path"};
-const char* LogConfig::kMountKey{"mount"};
-const char* LogConfig::kFpsKey{"fps"};
-const char* LogConfig::kDefaultPath{"/var/opt/deadeye"};
-
 LogConfig::LogConfig(std::string path, int fps, bool mount)
     : path(path), fps(fps), mount(mount) {}
 

--- a/daemon/src/config/log_config.h
+++ b/daemon/src/config/log_config.h
@@ -7,10 +7,10 @@ using json = nlohmann::json;
 namespace deadeye {
 
 struct LogConfig {
-  static char const* kFpsKey;
-  static char const* kPathKey;
-  static char const* kMountKey;
-  static char const* kDefaultPath;
+  static const char* kFpsKey;
+  static const char* kPathKey;
+  static const char* kMountKey;
+  static const char* kDefaultPath;
 
   std::string path{kDefaultPath};
   int fps{0};
@@ -30,11 +30,11 @@ struct LogConfig {
 void to_json(json& j, const LogConfig& l);
 void from_json(const json& j, LogConfig& l);
 
-inline bool operator==(LogConfig const& lhs, LogConfig const& rhs) {
+inline bool operator==(const LogConfig& lhs, const LogConfig& rhs) {
   return lhs.path == rhs.path && lhs.fps == rhs.fps && lhs.mount == rhs.mount;
 }
 
-inline bool operator!=(LogConfig const& lhs, LogConfig const& rhs) {
+inline bool operator!=(const LogConfig& lhs, const LogConfig& rhs) {
   return !(lhs == rhs);
 }
 

--- a/daemon/src/config/log_config.h
+++ b/daemon/src/config/log_config.h
@@ -7,10 +7,10 @@ using json = nlohmann::json;
 namespace deadeye {
 
 struct LogConfig {
-  static const char* kFpsKey;
-  static const char* kPathKey;
-  static const char* kMountKey;
-  static const char* kDefaultPath;
+  static constexpr auto kFpsKey = "fps";
+  static constexpr auto kPathKey = "path";
+  static constexpr auto kMountKey = "mount";
+  static constexpr auto kDefaultPath = "/var/opt/deadeye";
 
   std::string path{kDefaultPath};
   int fps{0};

--- a/daemon/src/config/pipeline_config.cpp
+++ b/daemon/src/config/pipeline_config.cpp
@@ -3,13 +3,6 @@
 using namespace deadeye;
 using json = nlohmann::json;
 
-const char* PipelineConfig::kSerialKey{"sn"};
-const char* PipelineConfig::kHsvHueKey{"hue"};
-const char* PipelineConfig::kHsvSatKey{"sat"};
-const char* PipelineConfig::kHsvValKey{"val"};
-const char* PipelineConfig::kFilterKey{"filter"};
-const char* PipelineConfig::kLogKey{"log"};
-
 PipelineConfig::PipelineConfig(int sn, hsv_t hue, hsv_t sat, hsv_t val,
                                FilterConfig filter, LogConfig log)
     : sn(sn), hue(hue), sat(sat), val(val), filter(filter), log(log) {}

--- a/daemon/src/config/pipeline_config.cpp
+++ b/daemon/src/config/pipeline_config.cpp
@@ -3,12 +3,12 @@
 using namespace deadeye;
 using json = nlohmann::json;
 
-char const* PipelineConfig::kSerialKey{"sn"};
-char const* PipelineConfig::kHsvHueKey{"hue"};
-char const* PipelineConfig::kHsvSatKey{"sat"};
-char const* PipelineConfig::kHsvValKey{"val"};
-char const* PipelineConfig::kFilterKey{"filter"};
-char const* PipelineConfig::kLogKey{"log"};
+const char* PipelineConfig::kSerialKey{"sn"};
+const char* PipelineConfig::kHsvHueKey{"hue"};
+const char* PipelineConfig::kHsvSatKey{"sat"};
+const char* PipelineConfig::kHsvValKey{"val"};
+const char* PipelineConfig::kFilterKey{"filter"};
+const char* PipelineConfig::kLogKey{"log"};
 
 PipelineConfig::PipelineConfig(int sn, hsv_t hue, hsv_t sat, hsv_t val,
                                FilterConfig filter, LogConfig log)

--- a/daemon/src/config/pipeline_config.h
+++ b/daemon/src/config/pipeline_config.h
@@ -20,12 +20,12 @@ std::string onoff(bool state) { return state ? "(on)" : "(off)"; }
 namespace deadeye {
 
 struct PipelineConfig {
-  static char const* kSerialKey;
-  static char const* kHsvHueKey;
-  static char const* kHsvSatKey;
-  static char const* kHsvValKey;
-  static char const* kFilterKey;
-  static char const* kLogKey;
+  static const char* kSerialKey;
+  static const char* kHsvHueKey;
+  static const char* kHsvSatKey;
+  static const char* kHsvValKey;
+  static const char* kFilterKey;
+  static const char* kLogKey;
 
   using hsv_t = std::array<int, 2>;
 
@@ -56,7 +56,7 @@ struct PipelineConfig {
   cv::Scalar HsvHigh() const { return cv::Scalar(hue[1], sat[1], val[1]); }
 
   template <typename OStream>
-  friend OStream& operator<<(OStream& os, PipelineConfig const& pc) {
+  friend OStream& operator<<(OStream& os, const PipelineConfig& pc) {
     std::string output = fmt::format(
         "PipelineConfig<sn={}, hue=[{},{}], sat=[{},{}], val=[{},{}], "
         "filter=<area=[{},{}] {}, solidity=[{},{}] {}, aspect=[{},{}] "
@@ -76,12 +76,12 @@ struct PipelineConfig {
 void to_json(json& j, const PipelineConfig& p);
 void from_json(const json& j, PipelineConfig& p);
 
-inline bool operator==(PipelineConfig const& lhs, PipelineConfig const& rhs) {
+inline bool operator==(const PipelineConfig& lhs, const PipelineConfig& rhs) {
   return lhs.sn == rhs.sn && lhs.hue == rhs.hue && lhs.sat == rhs.sat &&
          lhs.val == rhs.val && lhs.filter == rhs.filter && lhs.log == rhs.log;
 }
 
-inline bool operator!=(PipelineConfig const& lhs, PipelineConfig const& rhs) {
+inline bool operator!=(const PipelineConfig& lhs, const PipelineConfig& rhs) {
   return !(lhs == rhs);
 }
 

--- a/daemon/src/config/pipeline_config.h
+++ b/daemon/src/config/pipeline_config.h
@@ -20,12 +20,12 @@ std::string onoff(bool state) { return state ? "(on)" : "(off)"; }
 namespace deadeye {
 
 struct PipelineConfig {
-  static const char* kSerialKey;
-  static const char* kHsvHueKey;
-  static const char* kHsvSatKey;
-  static const char* kHsvValKey;
-  static const char* kFilterKey;
-  static const char* kLogKey;
+  static constexpr auto kSerialKey = "sn";
+  static constexpr auto kHsvHueKey = "hue";
+  static constexpr auto kHsvSatKey = "sat";
+  static constexpr auto kHsvValKey = "val";
+  static constexpr auto kFilterKey = "filter";
+  static constexpr auto kLogKey = "log";
 
   using hsv_t = std::array<int, 2>;
 

--- a/daemon/src/config/stream_config.cpp
+++ b/daemon/src/config/stream_config.cpp
@@ -5,15 +5,16 @@
 #include <ifaddrs.h>
 #include <spdlog/spdlog.h>
 #include <stdio.h>
+
 #include <sstream>
 
 using namespace deadeye;
 using json = nlohmann::json;
 
-char const* StreamConfig::kSerialKey{"sn"};
-char const* StreamConfig::kUrlKey{"url"};
-char const* StreamConfig::kViewKey{"view"};
-char const* StreamConfig::kContourKey{"contour"};
+const char* StreamConfig::kSerialKey{"sn"};
+const char* StreamConfig::kUrlKey{"url"};
+const char* StreamConfig::kViewKey{"view"};
+const char* StreamConfig::kContourKey{"contour"};
 
 namespace {
 std::string stream_url(int inum);
@@ -60,7 +61,7 @@ void deadeye::from_json(const json& j, StreamConfig& sc) {
 // iostream support
 //
 
-std::ostream& operator<<(std::ostream& os, StreamConfig const& sc) {
+std::ostream& operator<<(std::ostream& os, const StreamConfig& sc) {
   os << fmt::format("StreamConfig<{}, {}>", sc.sn, sc.url);
   return os;
 }

--- a/daemon/src/config/stream_config.cpp
+++ b/daemon/src/config/stream_config.cpp
@@ -11,11 +11,6 @@
 using namespace deadeye;
 using json = nlohmann::json;
 
-const char* StreamConfig::kSerialKey{"sn"};
-const char* StreamConfig::kUrlKey{"url"};
-const char* StreamConfig::kViewKey{"view"};
-const char* StreamConfig::kContourKey{"contour"};
-
 namespace {
 std::string stream_url(int inum);
 }
@@ -71,12 +66,16 @@ std::ostream& operator<<(std::ostream& os, const StreamConfig& sc) {
 //
 
 namespace {
-const uint32_t nm08 = htonl(0xFF000000);
-const uint32_t nm12 = htonl(0xFFF00000);
-const uint32_t nm16 = htonl(0xFFFF0000);
-const uint32_t n010 = htonl(0x0A000000) & nm08;  // 10.0.0.0-10.255.255.255
-const uint32_t n172 = htonl(0xAC100000) & nm12;  // 172.16.0.0-172.31.255.255
-const uint32_t n192 = htonl(0xC0A80000) & nm16;  // 192.168.0.0-192.168.255.255
+constexpr uint32_t nm08 = htonl(0xFF000000);
+constexpr uint32_t nm12 = htonl(0xFFF00000);
+constexpr uint32_t nm16 = htonl(0xFFFF0000);
+
+// 10.0.0.0-10.255.255.255
+constexpr uint32_t n010 = htonl(0x0A000000) & nm08;
+// 172.16.0.0-172.31.255.255
+constexpr uint32_t n172 = htonl(0xAC100000) & nm12;
+// 192.168.0.0-192.168.255.255
+constexpr uint32_t n192 = htonl(0xC0A80000) & nm16;
 
 bool is_private(struct sockaddr* addr) {
   if (addr == nullptr) return false;

--- a/daemon/src/config/stream_config.h
+++ b/daemon/src/config/stream_config.h
@@ -14,10 +14,10 @@ struct StreamConfig {
   enum class View { none, original, mask };
   enum class Contour { none, filter, all };
 
-  static char const* kSerialKey;
-  static char const* kUrlKey;
-  static char const* kViewKey;
-  static char const* kContourKey;
+  static const char* kSerialKey;
+  static const char* kUrlKey;
+  static const char* kViewKey;
+  static const char* kContourKey;
 
   int sn = 0;
   std::string url;
@@ -52,7 +52,7 @@ struct StreamConfig {
   }
 
   template <typename OStream>
-  friend OStream& operator<<(OStream& os, StreamConfig const& sc) {
+  friend OStream& operator<<(OStream& os, const StreamConfig& sc) {
     std::string view;
     switch (sc.view) {
       case View::none:
@@ -87,12 +87,12 @@ struct StreamConfig {
 void to_json(json& j, const StreamConfig& p);
 void from_json(const json& j, StreamConfig& p);
 
-inline bool operator==(StreamConfig const& lhs, StreamConfig const& rhs) {
+inline bool operator==(const StreamConfig& lhs, const StreamConfig& rhs) {
   return lhs.view == rhs.view && lhs.contour == rhs.contour &&
          lhs.url == rhs.url;
 }
 
-inline bool operator!=(StreamConfig const& lhs, StreamConfig const& rhs) {
+inline bool operator!=(const StreamConfig& lhs, const StreamConfig& rhs) {
   return !(lhs == rhs);
 }
 

--- a/daemon/src/config/stream_config.h
+++ b/daemon/src/config/stream_config.h
@@ -14,10 +14,10 @@ struct StreamConfig {
   enum class View { none, original, mask };
   enum class Contour { none, filter, all };
 
-  static const char* kSerialKey;
-  static const char* kUrlKey;
-  static const char* kViewKey;
-  static const char* kContourKey;
+  static constexpr auto kSerialKey = "sn";
+  static constexpr auto kUrlKey = "url";
+  static constexpr auto kViewKey = "view";
+  static constexpr auto kContourKey = "contour";
 
   int sn = 0;
   std::string url;

--- a/daemon/src/controller.cpp
+++ b/daemon/src/controller.cpp
@@ -98,7 +98,7 @@ Controller::~Controller() {
   try {
     nt::Flush(inst_);
     nt::DestroyEntryListenerPoller(poller_);
-  } catch (std::exception const& e) {
+  } catch (const std::exception& e) {
     spdlog::error("~Controller: {}", e.what());
   }
   spdlog::info("Deadeye Controller exiting.");

--- a/daemon/src/deadeye.h
+++ b/daemon/src/deadeye.h
@@ -37,13 +37,13 @@
 #endif
 
 #define DEADEYE_MAIN()                                                     \
-  int main(int argc, char **argv) {                                        \
+  int main(int argc, char** argv) {                                        \
     try {                                                                  \
       ::deadeye::log::Configure("deadeye");                                \
       ::deadeye::Pipelines pipelines({DE_P0, DE_P1, DE_P2, DE_P3, DE_P4}); \
       ::deadeye::Controller::Initialize(std::move(pipelines));             \
       ::deadeye::Controller::GetInstance().Run();                          \
-    } catch (std::exception const &e) {                                    \
+    } catch (const std::exception& e) {                                    \
       spdlog::critical("DEADEYE_MAIN: {}", e.what());                      \
       std::exit(EXIT_FAILURE);                                             \
     }                                                                      \

--- a/daemon/src/link/min_area_target_data.cpp
+++ b/daemon/src/link/min_area_target_data.cpp
@@ -7,19 +7,19 @@
 using namespace deadeye;
 using json = nlohmann::json;
 
-char const* MinAreaTargetData::kBLX{"blx"};
-char const* MinAreaTargetData::kBLY{"bly"};
-char const* MinAreaTargetData::kTLX{"tlx"};
-char const* MinAreaTargetData::kTLY{"tly"};
-char const* MinAreaTargetData::kTRX{"trx"};
-char const* MinAreaTargetData::kTRY{"try"};
-char const* MinAreaTargetData::kBRX{"brx"};
-char const* MinAreaTargetData::kBRY{"bry"};
-char const* MinAreaTargetData::kXKey{"x"};
-char const* MinAreaTargetData::kYKey{"y"};
-char const* MinAreaTargetData::kWKey{"w"};
-char const* MinAreaTargetData::kHKey{"h"};
-char const* MinAreaTargetData::kAngleKey{"a"};
+const char* MinAreaTargetData::kBLX{"blx"};
+const char* MinAreaTargetData::kBLY{"bly"};
+const char* MinAreaTargetData::kTLX{"tlx"};
+const char* MinAreaTargetData::kTLY{"tly"};
+const char* MinAreaTargetData::kTRX{"trx"};
+const char* MinAreaTargetData::kTRY{"try"};
+const char* MinAreaTargetData::kBRX{"brx"};
+const char* MinAreaTargetData::kBRY{"bry"};
+const char* MinAreaTargetData::kXKey{"x"};
+const char* MinAreaTargetData::kYKey{"y"};
+const char* MinAreaTargetData::kWKey{"w"};
+const char* MinAreaTargetData::kHKey{"h"};
+const char* MinAreaTargetData::kAngleKey{"a"};
 
 MinAreaTargetData::MinAreaTargetData(std::string id, int sn, bool valid,
                                      cv::RotatedRect rect, cv::Point2f center)

--- a/daemon/src/link/min_area_target_data.h
+++ b/daemon/src/link/min_area_target_data.h
@@ -8,19 +8,19 @@ using json = nlohmann::json;
 
 namespace deadeye {
 struct MinAreaTargetData : public TargetData {
-  static char const* kBLX;
-  static char const* kBLY;
-  static char const* kTLX;
-  static char const* kTLY;
-  static char const* kTRX;
-  static char const* kTRY;
-  static char const* kBRX;
-  static char const* kBRY;
-  static char const* kXKey;
-  static char const* kYKey;
-  static char const* kWKey;
-  static char const* kHKey;
-  static char const* kAngleKey;
+  static const char* kBLX;
+  static const char* kBLY;
+  static const char* kTLX;
+  static const char* kTLY;
+  static const char* kTRX;
+  static const char* kTRY;
+  static const char* kBRX;
+  static const char* kBRY;
+  static const char* kXKey;
+  static const char* kYKey;
+  static const char* kWKey;
+  static const char* kHKey;
+  static const char* kAngleKey;
 
   cv::RotatedRect rect;
   cv::Point2f offset;

--- a/daemon/src/link/target_data.cpp
+++ b/daemon/src/link/target_data.cpp
@@ -3,9 +3,9 @@
 using namespace deadeye;
 using json = nlohmann::json;
 
-char const* TargetData::kIdKey{"id"};
-char const* TargetData::kSerialKey{"sn"};
-char const* TargetData::kValidKey{"valid"};
+const char* TargetData::kIdKey{"id"};
+const char* TargetData::kSerialKey{"sn"};
+const char* TargetData::kValidKey{"valid"};
 
 TargetData::TargetData(std::string id, int serial, bool valid)
     : id(id), serial(serial), valid(valid) {}

--- a/daemon/src/link/target_data.h
+++ b/daemon/src/link/target_data.h
@@ -6,9 +6,9 @@ using json = nlohmann::json;
 
 namespace deadeye {
 struct TargetData {
-  static char const* kIdKey;
-  static char const* kSerialKey;
-  static char const* kValidKey;
+  static const char* kIdKey;
+  static const char* kSerialKey;
+  static const char* kValidKey;
 
   std::string id;
   int serial;
@@ -18,8 +18,8 @@ struct TargetData {
   virtual ~TargetData() = default;
   TargetData(std::string id, int serial, bool valid);
 
-  TargetData(TargetData const&) = delete;
-  TargetData& operator=(TargetData const&) = delete;
+  TargetData(const TargetData&) = delete;
+  TargetData& operator=(const TargetData&) = delete;
 
   virtual void DrawMarkers(cv::Mat& preview) const;
   virtual std::string Dump() const;  // json format

--- a/daemon/src/link/upright_target_data.cpp
+++ b/daemon/src/link/upright_target_data.cpp
@@ -7,12 +7,12 @@
 using namespace deadeye;
 using json = nlohmann::json;
 
-char const* UprightTargetData::kTLX{"tx"};
-char const* UprightTargetData::kTLY{"ty"};
-char const* UprightTargetData::kBRX{"bx"};
-char const* UprightTargetData::kBRY{"by"};
-char const* UprightTargetData::kXKey{"x"};
-char const* UprightTargetData::kYKey{"y"};
+const char* UprightTargetData::kTLX{"tx"};
+const char* UprightTargetData::kTLY{"ty"};
+const char* UprightTargetData::kBRX{"bx"};
+const char* UprightTargetData::kBRY{"by"};
+const char* UprightTargetData::kXKey{"x"};
+const char* UprightTargetData::kYKey{"y"};
 
 UprightTargetData::UprightTargetData(std::string id, int sn, bool valid,
                                      cv::Rect bb, cv::Point center)

--- a/daemon/src/link/upright_target_data.h
+++ b/daemon/src/link/upright_target_data.h
@@ -8,12 +8,12 @@ using json = nlohmann::json;
 
 namespace deadeye {
 struct UprightTargetData : public TargetData {
-  static char const* kTLX;
-  static char const* kTLY;
-  static char const* kBRX;
-  static char const* kBRY;
-  static char const* kXKey;
-  static char const* kYKey;
+  static const char* kTLX;
+  static const char* kTLY;
+  static const char* kBRX;
+  static const char* kBRY;
+  static const char* kXKey;
+  static const char* kYKey;
 
   cv::Rect bb;
   cv::Point offset;

--- a/daemon/src/pipeline/default_pipeline.h
+++ b/daemon/src/pipeline/default_pipeline.h
@@ -9,13 +9,13 @@ class DefaultPipeline : public AbstractPipeline {
   bool StartCapture() override;
   void StopCapture() override;
 
-  bool GrabFrame(cv::Mat &frame) override;
+  bool GrabFrame(cv::Mat& frame) override;
 
-  void FilterContours(FilterConfig const &filter, Contours const &src,
-                      Contours &dest) override;
+  void FilterContours(const FilterConfig& filter, const Contours& src,
+                      Contours& dest) override;
 
  protected:
-  TargetDataPtr ProcessTarget(Contours const &contours) override;
+  TargetDataPtr ProcessTarget(const Contours& contours) override;
   virtual std::string ToString() const override;
 
   cv::VideoCapture cap_;

--- a/daemon/src/pipeline/pipeline_logger.cpp
+++ b/daemon/src/pipeline/pipeline_logger.cpp
@@ -157,7 +157,7 @@ void PipelineLogger::operator()() {
   spdlog::trace("PipelineLogger<{}>: task exited", id_);
 }
 
-bool PipelineLogger::CheckMount(LogConfig const& config) {
+bool PipelineLogger::CheckMount(const LogConfig& config) {
   struct stat mnt;
   struct stat parent;
 
@@ -190,7 +190,7 @@ bool PipelineLogger::CheckMount(LogConfig const& config) {
   }
 }
 
-bool PipelineLogger::CheckDir(LogConfig const& config) {
+bool PipelineLogger::CheckDir(const LogConfig& config) {
   // verify base path is dir
   DIR* dir = opendir(config.path.c_str());
   if (dir) {

--- a/daemon/src/pipeline/pipeline_logger.h
+++ b/daemon/src/pipeline/pipeline_logger.h
@@ -35,8 +35,8 @@ class PipelineLogger {
   void operator()();
 
  private:
-  bool CheckMount(LogConfig const& config);
-  bool CheckDir(LogConfig const& config);
+  bool CheckMount(const LogConfig& config);
+  bool CheckDir(const LogConfig& config);
 
   std::string id_;
 

--- a/daemon/src/pipeline/pipeline_ops.h
+++ b/daemon/src/pipeline/pipeline_ops.h
@@ -3,15 +3,15 @@
 #include <opencv2/imgproc.hpp>
 
 namespace deadeye {
-inline void MaskFrame(cv::Mat const& frame, cv::Mat& output,
-                      cv::Scalar const& low, cv::Scalar const& high) {
+inline void MaskFrame(const cv::Mat& frame, cv::Mat& output,
+                      const cv::Scalar& low, const cv::Scalar& high) {
   cv::cvtColor(frame, output, cv::COLOR_BGR2HSV);
   cv::inRange(output, (low), (high), output);
 }
 
 using Contours = std::vector<std::vector<cv::Point>>;
 
-inline void FindContours(cv::Mat const& mask, Contours& contours) {
+inline void FindContours(const cv::Mat& mask, Contours& contours) {
   contours.clear();
   cv::findContours(mask, contours, cv::RETR_EXTERNAL, cv::CHAIN_APPROX_SIMPLE);
 }
@@ -19,8 +19,8 @@ inline void FindContours(cv::Mat const& mask, Contours& contours) {
 /**
  * Filters according to filter; dest is copy of src if filters not enabled;
  */
-inline void GeometricContoursFilter(FilterConfig const& filter,
-                                    Contours const& src, Contours& dest) {
+inline void GeometricContoursFilter(const FilterConfig& filter,
+                                    const Contours& src, Contours& dest) {
   if (!filter.enabled) {
     dest = src;
     return;
@@ -32,7 +32,7 @@ inline void GeometricContoursFilter(FilterConfig const& filter,
   if (filter.area_enabled) assert(filter.frame_area > 0);
 #endif
 
-  for (auto const& contour : src) {
+  for (const auto& contour : src) {
     // set these to true if filter is skipped, false otherwise
     bool area_ok = !filter.area_enabled;
     bool solidity_ok = !filter.solidity_enabled;


### PR DESCRIPTION
NL.18: Use C++-style declarator layout
NL.26: Use conventional const notation