### PR TITLE
Clean up additional IDE warnings in /daemon

### DIFF
--- a/daemon/src/capture/capture_type.h
+++ b/daemon/src/capture/capture_type.h
@@ -10,5 +10,5 @@ NLOHMANN_JSON_SERIALIZE_ENUM(CaptureType, {
                                               {CaptureType::test, "test"},
                                               {CaptureType::file, "file"},
                                               {CaptureType::usb, "usb"},
-                                          });
+                                          })
 }  // namespace deadeye

--- a/daemon/src/capture/gstreamer.cpp
+++ b/daemon/src/capture/gstreamer.cpp
@@ -15,4 +15,4 @@ bool Gstreamer::Grab(cv::Mat& frame) {
   bool is_ok = cap_.read(frame);
   if (is_ok && is_yuv_) cv::cvtColor(frame, frame, cv::COLOR_YUV2BGR_UYVY);
   return is_ok;
-};
+}

--- a/daemon/src/capture/usb_cscore.cpp
+++ b/daemon/src/capture/usb_cscore.cpp
@@ -1,7 +1,6 @@
 #include "capture/usb_cscore.h"
 
 #include <cscore_oo.h>
-#include <fmt/core.h>
 #include <spdlog/spdlog.h>
 
 using namespace deadeye;

--- a/daemon/src/capture/usb_gstreamer.cpp
+++ b/daemon/src/capture/usb_gstreamer.cpp
@@ -6,7 +6,7 @@
 using namespace deadeye;
 using json = nlohmann::json;
 
-UsbGStreamer::UsbGStreamer(const CaptureConfig& config) {
+[[maybe_unused]] UsbGStreamer::UsbGStreamer(const CaptureConfig& config) {
   auto pipeline = BuildV4L2Pipeline(config);
   is_yuv_ = false;
   cap_.open(pipeline, cv::CAP_GSTREAMER);

--- a/daemon/src/capture/usb_gstreamer.h
+++ b/daemon/src/capture/usb_gstreamer.h
@@ -8,7 +8,7 @@ std::string BuildV4L2Pipeline(const CaptureConfig& config);
 
 class UsbGStreamer : public Gstreamer {
  public:
-  explicit UsbGStreamer(const CaptureConfig& config);
+  [[maybe_unused]] explicit UsbGStreamer(const CaptureConfig& config);
   ~UsbGStreamer() override = default;
 };
 

--- a/daemon/src/config/deadeye_config.h
+++ b/daemon/src/config/deadeye_config.h
@@ -9,7 +9,6 @@
 
 #define DE_DEADEYE_TABLE "/Deadeye"
 #define DE_CAPTURE "/Capture"
-#define DE_CONFIG "/Config"
 #define DE_INFO "/Info"
 #define DE_LIGHTS "/Light"
 #define DE_LINK "/Link"
@@ -25,15 +24,12 @@
 #define DE_ON "On"
 #define DE_OFF "Off"
 #define DE_BLINK "Blink"
-#define DE_ADDRESS "Address"
-#define DE_PORT "Port"
 
 #define DE_CAMERA_CONTROL(inum, param) DE_CAMERA_CONTROL_TABLE(inum) "/" param
 #define DE_LIGHTS_CONTROL(inum, param) DE_LIGHTS_CONTROL_TABLE(inum) "/" param
 #define DE_CAPTURE_CONFIG_ENTRY(inum) DE_CONFIG_TABLE "/" inum DE_CAPTURE
 #define DE_PIPELINE_CONFIG_ENTRY(inum) DE_CONFIG_TABLE "/" inum DE_PIPELINE
 #define DE_STREAM_CONFIG_ENTRY(inum) DE_CONFIG_TABLE "/" inum DE_STREAM
-#define DE_INFO_ENTRY(inum) DE_CONFIG_TABLE "/" inum DE_INFO
 #define DE_LINK_ENTRY DE_DEADEYE_TABLE DE_LINK
 
 #define CLIENT_PORT DEADEYE_CLIENT_PORT
@@ -49,5 +45,5 @@ std::string PipelineConfigEntryPath(int inum);
 std::string StreamConfigEntryPath(int inum);
 std::string InfoEntryPath(int inum);
 
-static const cv::Size kStreamSize{320, 240};
+static const cv::Size kStreamSize{320, 240}; // NOLINT
 }  // namespace deadeye

--- a/daemon/src/config/deadeye_version.h
+++ b/daemon/src/config/deadeye_version.h
@@ -4,10 +4,9 @@
 namespace deadeye {
 
 std::string GetDeadeyeVersion();
-unsigned GetDeadeyeVersionMajor();
-unsigned GetDeadeyeVersionMinor();
-unsigned GetDeadeyeVersionPatch();
-unsigned GetDeadeyeVersionTweak();
-unsigned GetDeadeyeCommitsSinceVersionChange();
+[[maybe_unused]] unsigned GetDeadeyeVersionMajor();
+[[maybe_unused]] unsigned GetDeadeyeVersionMinor();
+[[maybe_unused]] unsigned GetDeadeyeVersionPatch();
+[[maybe_unused]] unsigned GetDeadeyeVersionTweak();
 
 }  // namespace deadeye

--- a/daemon/src/config/log_config.h
+++ b/daemon/src/config/log_config.h
@@ -13,7 +13,7 @@ struct LogConfig {
   static constexpr auto kMountKey = "mount";
   static constexpr auto kDefaultPath = "/var/opt/deadeye";
 
-  LogType type;
+  LogType type{};
   std::string path{kDefaultPath};
   int fps{0};
   bool mount{true};

--- a/daemon/src/config/stream_config.cpp
+++ b/daemon/src/config/stream_config.cpp
@@ -67,16 +67,16 @@ std::ostream& operator<<(std::ostream& os, const StreamConfig& sc) {
 //
 
 namespace {
-const uint32_t nm08 = htonl(0xFF000000);
-const uint32_t nm12 = htonl(0xFFF00000);
-const uint32_t nm16 = htonl(0xFFFF0000);
+const uint32_t nm08 = htonl(0xFF000000); // NOLINT
+const uint32_t nm12 = htonl(0xFFF00000); // NOLINT
+const uint32_t nm16 = htonl(0xFFFF0000); // NOLINT
 
 // 10.0.0.0-10.255.255.255
-const uint32_t n010 = htonl(0x0A000000) & nm08;
+const uint32_t n010 = htonl(0x0A000000) & nm08; // NOLINT
 // 172.16.0.0-172.31.255.255
-const uint32_t n172 = htonl(0xAC100000) & nm12;
+const uint32_t n172 = htonl(0xAC100000) & nm12; // NOLINT
 // 192.168.0.0-192.168.255.255
-const uint32_t n192 = htonl(0xC0A80000) & nm16;
+const uint32_t n192 = htonl(0xC0A80000) & nm16; // NOLINT
 
 bool is_private(struct sockaddr* addr) {
   if (addr == nullptr) return false;
@@ -110,7 +110,10 @@ std::string first_rfc1918() {
   }
 
   freeifaddrs(ifaddr);
+#pragma clang diagnostic push
+#pragma ide diagnostic ignored "LocalValueEscapesScope"
   return addr;
+#pragma clang diagnostic pop
 }
 
 std::string stream_url(int inum) {

--- a/daemon/src/config/stream_config.h
+++ b/daemon/src/config/stream_config.h
@@ -19,8 +19,8 @@ struct StreamConfig {
 
   int sn = 0;
   std::string url;
-  View view;
-  Contour contour;
+  View view{};
+  Contour contour{};
 
   /**
    * Default constructor.

--- a/daemon/src/controller.cpp
+++ b/daemon/src/controller.cpp
@@ -421,6 +421,9 @@ void Controller::Run() {
 }
 
 void Controller::ShutDown() {
+  nt::DestroyEntryListenerPoller(poller_);
+  nt::RemoveEntryListener(entry_listener_);
+
   // fsm dispatches to all instances
   if (has_active_pipeline_[0]) {
     Camera<0>::dispatch(CameraOff());

--- a/daemon/src/controller.cpp
+++ b/daemon/src/controller.cpp
@@ -33,12 +33,15 @@ std::atomic<bool> quit{false};
 
 void signal_handler([[maybe_unused]] int signal) { quit = true; }
 
+#pragma clang diagnostic push
+#pragma ide diagnostic ignored "misc-no-recursion"
 /**
  * From http://www.rioki.org/2016/03/31/cpp-switch-string.html
  */
 constexpr unsigned int hash(const char* str, int h = 0) {
   return !str[h] ? 5381 : (hash(str, h + 1) * 33) ^ str[h];
 }
+#pragma clang diagnostic pop
 
 }  // namespace
 

--- a/daemon/src/controller.cpp
+++ b/daemon/src/controller.cpp
@@ -48,7 +48,8 @@ constexpr unsigned int hash(const char* str, int h = 0) {
 /**
  * Constructor for Controller.
  */
-Controller::Controller(Pipelines *pipelines) {
+Controller::Controller(Pipelines* pipelines)
+    : inst_{0}, poller_{0}, entry_listener_{0}, has_active_pipeline_{} {
   spdlog::info("Deadeye {}", GetDeadeyeVersion());
 
   assert(pipelines);
@@ -465,7 +466,8 @@ void Controller::StartNetworkTables() {
 
   char* env_nt_port = std::getenv("DEADEYE_NT_PORT");
   const unsigned int nt_port =
-    env_nt_port ? static_cast<unsigned int>(std::stoi(env_nt_port)) : NT_DEFAULT_PORT;
+      env_nt_port ? static_cast<unsigned int>(std::stoi(env_nt_port))
+                  : NT_DEFAULT_PORT;
 
   // create own NT server if DEADEYE_NT_SERVER=127.0.0.1
   if (std::strncmp("127.0.0.1", nt_server, 15) == 0) {

--- a/daemon/src/controller.cpp
+++ b/daemon/src/controller.cpp
@@ -48,7 +48,7 @@ constexpr unsigned int hash(const char* str, int h = 0) {
 /**
  * Constructor for Controller.
  */
-Controller::Controller(PipelinesPtr pipelines) {
+Controller::Controller(Pipelines *pipelines) {
   spdlog::info("Deadeye {}", GetDeadeyeVersion());
 
   assert(pipelines);

--- a/daemon/src/controller.h
+++ b/daemon/src/controller.h
@@ -10,7 +10,6 @@ static constexpr int kNumCameras = 5;
 
 class Pipeline;
 using Pipelines = std::array<std::unique_ptr<Pipeline>, kNumCameras>;
-using PipelinesPtr = Pipelines* const;
 
 class Controller {
  public:
@@ -26,11 +25,12 @@ class Controller {
   void ShutDown();
 
  private:
-  static Controller& getInstanceImpl(PipelinesPtr pipelines = nullptr) {
+  static Controller& getInstanceImpl(Pipelines* pipelines = nullptr) {
     static Controller instance{pipelines};
     return instance;
   }
-  explicit Controller(PipelinesPtr pipelines);
+
+  explicit Controller(Pipelines *pipelines);
 
   void StartNetworkTables();
 

--- a/daemon/src/hardware/camera.cpp
+++ b/daemon/src/hardware/camera.cpp
@@ -2,7 +2,6 @@
 
 #include <future>
 
-#include "controller.h"
 #include "lights.h"
 
 using namespace std::chrono_literals;

--- a/daemon/src/hardware/camera.h
+++ b/daemon/src/hardware/camera.h
@@ -21,7 +21,7 @@ namespace deadeye {
 class Pipeline;
 
 template <class T>
-using owner = T;
+using owner [[maybe_unused]] = T;
 
 // ---------------------------------------------------------------------------
 // Events
@@ -62,21 +62,21 @@ class Camera : public tinyfsm::Fsm<Camera<inum>> {
   }
 
  private:
-  void react(tinyfsm::Event const&) {}  // default
+  [[maybe_unused]] void react(tinyfsm::Event const&) {}
 
-  virtual void react(CameraOn const&) {}
-  virtual void react(CameraOff const&) {}
-  virtual void react(ConfigCapture const& c) {
+  [[maybe_unused]] virtual void react(CameraOn const&) {}
+  [[maybe_unused]] virtual void react(CameraOff const&) {}
+  [[maybe_unused]] virtual void react(ConfigCapture const& c) {
     Camera<inum>::pipeline_runner_.Configure(c.config);
   }
-  virtual void react(ConfigPipeline const& c) {
+  [[maybe_unused]] virtual void react(ConfigPipeline const& c) {
     Camera<inum>::pipeline_runner_.Configure(c.config);
   }
-  virtual void react(ConfigStream const& s) {
+  [[maybe_unused]] virtual void react(ConfigStream const& s) {
     Camera<inum>::pipeline_runner_.Configure(s.config);
   }
 
-  virtual void entry() = 0;
+  [[maybe_unused]] virtual void entry() = 0;
   virtual void exit() = 0;
 
  protected:
@@ -94,7 +94,7 @@ class Camera : public tinyfsm::Fsm<Camera<inum>> {
 
 // state variable definitions
 template <int inum>
-Runner Camera<inum>::pipeline_runner_;
+Runner Camera<inum>::pipeline_runner_; // NOLINT
 
 template <int inum>
 std::future<void> Camera<inum>::pipeline_future_;

--- a/daemon/src/hardware/led_drive.cpp
+++ b/daemon/src/hardware/led_drive.cpp
@@ -1,9 +1,5 @@
 #include "led_drive.h"
 
-#include <spdlog/spdlog.h>
-
-#include "config/deadeye_config.h"
-
 using namespace deadeye;
 
 #ifdef __aarch64__
@@ -23,7 +19,7 @@ void LedDrive::On() { line_.set_value(0); }
 
 void LedDrive::Off() { line_.set_value(1); }
 #else
-LedDrive::LedDrive(int inum) {}
+LedDrive::LedDrive([[maybe_unused]] int inum) {}
 void LedDrive::On() {}
 void LedDrive::Off() {}
 #endif

--- a/daemon/src/hardware/led_drive.h
+++ b/daemon/src/hardware/led_drive.h
@@ -8,7 +8,7 @@ namespace deadeye {
 
 class LedDrive {
  public:
-  explicit LedDrive(int inum);
+  explicit LedDrive([[maybe_unused]] int inum);
 
   void On();
   void Off();

--- a/daemon/src/hardware/lights.cpp
+++ b/daemon/src/hardware/lights.cpp
@@ -6,8 +6,6 @@
 #include <thread>
 #include <tinyfsm.hpp>
 
-#include "controller.h"
-
 using namespace deadeye;
 
 namespace {
@@ -69,6 +67,8 @@ class Blinking : public Lights<inum> {
     spdlog::info("Lights<{}{}> blink", DEADEYE_UNIT, inum);
   }
 
+#pragma clang diagnostic push
+#pragma ide diagnostic ignored "UnreachableCallsOfFunction"
   void CancelTask() {
     base::cancel_task_ = true;
     if (base::task_future_.valid()) {
@@ -80,6 +80,7 @@ class Blinking : public Lights<inum> {
       }
     }
   }
+#pragma clang diagnostic pop
 
   void react(LightsOn const &) override {
     CancelTask();

--- a/daemon/src/hardware/lights.h
+++ b/daemon/src/hardware/lights.h
@@ -28,13 +28,13 @@ class Lights : public tinyfsm::Fsm<Lights<inum>> {
 
  private:
   // default reaction for unhandled events
-  void react(tinyfsm::Event const &) {}
+  [[maybe_unused]] void react(tinyfsm::Event const &) {}
 
-  virtual void react(LightsOn const &) {}
-  virtual void react(LightsOff const &) {}
-  virtual void react(LightsBlink const &) {}
+  [[maybe_unused]] virtual void react(LightsOn const &) {}
+  [[maybe_unused]] virtual void react(LightsOff const &) {}
+  [[maybe_unused]] virtual void react(LightsBlink const &) {}
 
-  virtual void entry() = 0;
+  [[maybe_unused]] virtual void entry() = 0;
   virtual void exit() = 0;
 
  protected:
@@ -57,6 +57,6 @@ template <int inum>
 std::atomic<bool> Lights<inum>::cancel_task_{false};
 
 template <int inum>
-LedDrive Lights<inum>::led_{inum};
+LedDrive Lights<inum>::led_{inum}; // NOLINT
 
 }  // namespace deadeye

--- a/daemon/src/link/link.cpp
+++ b/daemon/src/link/link.cpp
@@ -28,7 +28,7 @@ Link::Link(int inum) : id_(DEADEYE_UNIT + std::to_string(inum)) {
   if (fd_ == -1)
     spdlog::critical("Link<{}> send socket error: {}", id_, strerror(errno));
 
-  sockaddr_in addr;
+  sockaddr_in addr{};
   addr.sin_family = AF_INET;
   addr.sin_port = htons(link_config.port);
   inet_pton(AF_INET, link_config.address.c_str(), &addr.sin_addr);

--- a/daemon/src/link/link.h
+++ b/daemon/src/link/link.h
@@ -24,7 +24,7 @@ class Link {
   bool enabled_;
   std::string id_;
   int fd_;
-  LinkConfig GetConfig();
+  static LinkConfig GetConfig();
 };
 
 }  // namespace deadeye

--- a/daemon/src/link/target_data.cpp
+++ b/daemon/src/link/target_data.cpp
@@ -1,5 +1,7 @@
 #include "target_data.h"
 
+#include <utility>
+
 using namespace deadeye;
 using json = nlohmann::json;
 
@@ -9,7 +11,7 @@ const char* TargetData::kValidKey{"v"};
 const char* TargetData::kDataKey{"d"};
 
 TargetData::TargetData(std::string id, int serial, bool valid)
-    : id(id), serial(serial), valid(valid) {}
+    : id(std::move(std::move(id))), serial(serial), valid(valid) {}
 
 void TargetData::DrawMarkers(cv::Mat& preview) const {}
 

--- a/daemon/src/link/target_data.h
+++ b/daemon/src/link/target_data.h
@@ -12,8 +12,8 @@ struct TargetData {
   static const char* kDataKey;
 
   std::string id;
-  int serial;
-  bool valid;
+  int serial{};
+  bool valid{};
 
   TargetData() = default;
   virtual ~TargetData() = default;

--- a/daemon/src/link/target_list_target_data.cpp
+++ b/daemon/src/link/target_list_target_data.cpp
@@ -12,7 +12,7 @@ using json = nlohmann::json;
 namespace {
 // minimum datagram size: IPv4 = 576 IPv6 = 1280
 constexpr int MAX_SERIALIZED_SIZE = 1000;
-const cv::Scalar BB_COLOR{20, 255, 20};
+const cv::Scalar BB_COLOR{20, 255, 20}; // NOLINT
 }  // namespace
 
 TargetListTargetData::TargetListTargetData(const std::string& id, const int sn,
@@ -27,6 +27,8 @@ void TargetListTargetData::DrawMarkers(cv::Mat& preview) const {
   }
 }
 
+#pragma clang diagnostic push
+#pragma ide diagnostic ignored "misc-no-recursion"
 std::string TargetListTargetData::Dump() const {
   json j = json{{TargetData::kIdKey, id},
                 {TargetData::kSerialKey, serial},
@@ -45,6 +47,7 @@ std::string TargetListTargetData::Dump() const {
 
   return serialized;
 }
+#pragma clang diagnostic pop
 
 std::string TargetListTargetData::ToString() const {
   return fmt::format("id={} sn={} val={})", id, serial, valid);

--- a/daemon/src/log/capture.cpp
+++ b/daemon/src/log/capture.cpp
@@ -3,13 +3,14 @@
 #include <fmt/core.h>
 
 #include <opencv2/imgcodecs.hpp>
+#include <utility>
 
 using namespace deadeye::logger;
 
-Capture::Capture(std::string id, CaptureConfig capture_config,
-                 LogConfig log_config, LoggerQueue& queue,
+Capture::Capture(std::string id, const CaptureConfig& capture_config,
+                 const LogConfig& log_config, LoggerQueue& queue,
                  std::atomic<bool>& cancel)
-    : LoggerImpl(id, log_config, queue, cancel) {}
+    : LoggerImpl(std::move(id), log_config, queue, cancel) {}
 
 void Capture::Run() {
   int seq = 1;

--- a/daemon/src/log/capture.h
+++ b/daemon/src/log/capture.h
@@ -2,16 +2,14 @@
 
 #include "log/logger_impl.h"
 
-namespace deadeye {
-namespace logger {
+namespace deadeye::logger {
 
 class Capture : public LoggerImpl {
  public:
-  Capture(std::string id, CaptureConfig capture_config, LogConfig log_config,
+  Capture(std::string id, const CaptureConfig& capture_config, const LogConfig& log_config,
           LoggerQueue& queue, std::atomic<bool>& cancel);
 
   void Run() override;
 };
 
-}  // namespace logger
 }  // namespace deadeye

--- a/daemon/src/log/four_up.cpp
+++ b/daemon/src/log/four_up.cpp
@@ -3,25 +3,21 @@
 #include <fmt/core.h>
 #include <spdlog/spdlog.h>
 
-#include <cstring>
 #include <nlohmann/json.hpp>
 #include <opencv2/core.hpp>
 #include <opencv2/imgcodecs.hpp>
 #include <sstream>
+#include <utility>
 
 #include "pipeline/pipeline_ops.h"
 
 using namespace deadeye::logger;
 using json = nlohmann::json;
 
-namespace {
-static const cv::Size kFrameSize{640, 360};
-}
-
-FourUp::FourUp(std::string id, CaptureConfig capture_config,
-               PipelineConfig pipeline_config, LogConfig log_config,
+FourUp::FourUp(std::string id, const CaptureConfig& capture_config,
+               const PipelineConfig& pipeline_config, const LogConfig& log_config,
                LoggerQueue& queue, std::atomic<bool>& cancel)
-    : LoggerImpl(id, log_config, queue, cancel),
+    : LoggerImpl(std::move(id), log_config, queue, cancel),
       width_(capture_config.width),
       height_(capture_config.height),
       hsv_low_(pipeline_config.HsvLow()),

--- a/daemon/src/log/four_up.h
+++ b/daemon/src/log/four_up.h
@@ -13,8 +13,8 @@ namespace deadeye::logger {
 
 class FourUp : public LoggerImpl {
  public:
-  FourUp(std::string id, CaptureConfig capture_config,
-         PipelineConfig pipeline_config, LogConfig log_config,
+  FourUp(std::string id, const CaptureConfig& capture_config,
+         const PipelineConfig& pipeline_config, const LogConfig& log_config,
          LoggerQueue& queue, std::atomic<bool>& cancel);
   void Run() override;
 

--- a/daemon/src/log/log_type.h
+++ b/daemon/src/log/log_type.h
@@ -7,6 +7,6 @@ namespace deadeye {
 enum class LogType { capture, four_up };
 
 NLOHMANN_JSON_SERIALIZE_ENUM(LogType, {{LogType::capture, "capture"},
-                                       {LogType::four_up, "four_up"}});
+                                       {LogType::four_up, "four_up"}})
 
 }  // namespace deadeye

--- a/daemon/src/log/logger.h
+++ b/daemon/src/log/logger.h
@@ -6,6 +6,7 @@
 #include <future>
 #include <memory>
 #include <opencv2/core/mat.hpp>
+#include <utility>
 
 #include "log/capture.h"
 #include "log/four_up.h"
@@ -16,9 +17,9 @@ namespace deadeye {
 
 class Logger {
  public:
-  Logger() {}
-  Logger(const std::string id, const CaptureConfig capture_config,
-         const PipelineConfig pipeline_config, const LogConfig log_config) {
+  Logger() = default;
+  Logger(const std::string& id, const CaptureConfig& capture_config,
+         const PipelineConfig& pipeline_config, const LogConfig& log_config) {
     switch (log_config.type) {
       case LogType::capture:
         logger_ = std::make_unique<logger::Capture>(
@@ -39,10 +40,10 @@ class Logger {
     spdlog::debug("Logger::Run starting async logging task");
   }
 
-  void Log(cv::Mat const frame, Contours filtered_contours,
+  void Log(cv::Mat const& frame, Contours filtered_contours,
            std::unique_ptr<TargetData> target) {
     queue_.enqueue(
-        logger::LogEntry{frame.clone(), filtered_contours, std::move(target)});
+        logger::LogEntry{frame.clone(), std::move(filtered_contours), std::move(target)});
   }
 
   void Stop() {

--- a/daemon/src/log/logger_impl.cpp
+++ b/daemon/src/log/logger_impl.cpp
@@ -3,13 +3,15 @@
 #include <dirent.h>
 #include <sys/stat.h>
 
+#include <utility>
+
 using namespace deadeye::logger;
 
 int LoggerImpl::enable_count_{0};
 
-LoggerImpl::LoggerImpl(std::string id, LogConfig config, LoggerQueue& queue,
+LoggerImpl::LoggerImpl(std::string id, const LogConfig& config, LoggerQueue& queue,
                        std::atomic<bool>& cancel)
-    : id_{id},
+    : id_{std::move(std::move(id))},
       enabled_{config.fps > 0 && CheckMount(config) && CheckDir(config)},
       queue_(queue),
       cancel_{cancel} {
@@ -19,8 +21,8 @@ LoggerImpl::LoggerImpl(std::string id, LogConfig config, LoggerQueue& queue,
 }
 
 bool LoggerImpl::CheckMount(const LogConfig& config) {
-  struct stat mnt;
-  struct stat parent;
+  struct stat mnt{};
+  struct stat parent{};
 
   // check mount point
   if (stat(config.path.c_str(), &mnt)) {

--- a/daemon/src/log/logger_impl.h
+++ b/daemon/src/log/logger_impl.h
@@ -28,7 +28,7 @@ using LoggerQueue =
 
 class LoggerImpl {
  public:
-  LoggerImpl(std::string id, LogConfig config, LoggerQueue& queue,
+  LoggerImpl(std::string id, const LogConfig& config, LoggerQueue& queue,
              std::atomic<bool>& cancel);
   virtual ~LoggerImpl() = default;
 

--- a/daemon/src/pipeline/min_area_rect_pipeline.cpp
+++ b/daemon/src/pipeline/min_area_rect_pipeline.cpp
@@ -1,7 +1,6 @@
 #include "min_area_rect_pipeline.h"
 
 #include <fmt/core.h>
-#include <spdlog/spdlog.h>
 
 #include <opencv2/imgproc.hpp>
 #include <utility>
@@ -10,7 +9,7 @@
 
 using namespace deadeye;
 
-MinAreaRectPipeline::MinAreaRectPipeline(int inum, std::string name)
+[[maybe_unused]] MinAreaRectPipeline::MinAreaRectPipeline(int inum, std::string name)
     : AbstractPipeline{inum, std::move(name)} {}
 
 void MinAreaRectPipeline::Configure(const CaptureConfig& config) {

--- a/daemon/src/pipeline/min_area_rect_pipeline.h
+++ b/daemon/src/pipeline/min_area_rect_pipeline.h
@@ -4,7 +4,7 @@
 namespace deadeye {
 class MinAreaRectPipeline : public AbstractPipeline {
  public:
-  MinAreaRectPipeline(int inum, std::string name);
+  [[maybe_unused]] MinAreaRectPipeline(int inum, std::string name);
 
   void Configure(const CaptureConfig& config) override;
 

--- a/daemon/src/pipeline/runner.cpp
+++ b/daemon/src/pipeline/runner.cpp
@@ -12,6 +12,8 @@
 #include "log/logger.h"
 #include "pipeline/streamer.h"
 
+#pragma clang diagnostic push
+#pragma ide diagnostic ignored "NullDereference"
 using namespace deadeye;
 
 void Runner::SetPipeline(std::unique_ptr<Pipeline> pipeline) {
@@ -146,8 +148,10 @@ void Runner::Stop() { cancel_ = true; }
 
 void Runner::LogTickMeter(cv::TickMeter& tm) {
   spdlog::info("{}: stopping", *pipeline_);
-  double avg = tm.getTimeSec() / tm.getCounter();
+  double avg = tm.getTimeSec() / static_cast<double>(tm.getCounter());
   double fps = 1.0 / avg;
   spdlog::info("{}: avg. time = {:6.3f} ms, FPS = {:5.2f}", *pipeline_,
                avg * 1000.0, fps);
 }
+
+#pragma clang diagnostic pop

--- a/daemon/src/pipeline/streamer.cpp
+++ b/daemon/src/pipeline/streamer.cpp
@@ -10,7 +10,10 @@ using namespace deadeye;
 
 namespace {
 void ResetCScoreLogging();
+#pragma clang diagnostic push
+#pragma ide diagnostic ignored "misc-no-recursion"
 int gcd(int a, int b) { return (b == 0) ? a : gcd(b, a % b); }
+#pragma clang diagnostic pop
 }  // namespace
 
 Streamer::Streamer(const Pipeline* pipeline, const cv::Size size)

--- a/daemon/src/pipeline/target_list_pipeline.cpp
+++ b/daemon/src/pipeline/target_list_pipeline.cpp
@@ -10,7 +10,8 @@
 
 using namespace deadeye;
 
-TargetListPipeline::TargetListPipeline(int inum, std::string name)
+[[maybe_unused]] TargetListPipeline::TargetListPipeline(int inum,
+                                                        std::string name)
     : AbstractPipeline{inum, std::move(name)} {}
 
 void TargetListPipeline::Configure(const CaptureConfig& config) {
@@ -24,7 +25,7 @@ std::unique_ptr<TargetData> TargetListPipeline::ProcessContours(
 
   for (const auto& contour : contours) {
     cv::Rect bb = cv::boundingRect(contour);
-    int area = std::round(cv::contourArea(contour));
+    int area = static_cast<int>(std::round(cv::contourArea(contour)));
     targets.push_back({bb.x, bb.y, bb.width, bb.height, area});
   }
 

--- a/daemon/src/pipeline/target_list_pipeline.h
+++ b/daemon/src/pipeline/target_list_pipeline.h
@@ -4,7 +4,7 @@
 namespace deadeye {
 class TargetListPipeline : public AbstractPipeline {
  public:
-  TargetListPipeline(int inum, std::string name);
+  [[maybe_unused]] TargetListPipeline(int inum, std::string name);
 
   void Configure(const CaptureConfig& config) override;
 

--- a/daemon/src/pipeline/upright_rect_pipeline.cpp
+++ b/daemon/src/pipeline/upright_rect_pipeline.cpp
@@ -1,7 +1,6 @@
 #include "upright_rect_pipeline.h"
 
 #include <fmt/core.h>
-#include <spdlog/spdlog.h>
 
 #include <opencv2/imgproc.hpp>
 #include <utility>
@@ -12,7 +11,7 @@
 
 using namespace deadeye;
 
-UprightRectPipeline::UprightRectPipeline(int inum, std::string name)
+[[maybe_unused]] UprightRectPipeline::UprightRectPipeline(int inum, std::string name)
     : AbstractPipeline{inum, std::move(name)} {}
 
 void UprightRectPipeline::Configure(const CaptureConfig& config) {

--- a/daemon/src/pipeline/upright_rect_pipeline.h
+++ b/daemon/src/pipeline/upright_rect_pipeline.h
@@ -4,7 +4,7 @@
 namespace deadeye {
 class UprightRectPipeline : public AbstractPipeline {
  public:
-  UprightRectPipeline(int inum, std::string name);
+  [[maybe_unused]] UprightRectPipeline(int inum, std::string name);
 
   void Configure(const CaptureConfig& config) override;
 

--- a/daemon/tests/pipeline/pipeline_ops_tests.cpp
+++ b/daemon/tests/pipeline/pipeline_ops_tests.cpp
@@ -12,7 +12,7 @@ TEST_CASE("FindContours", "[ops]") {
     PipelineConfig pc;
     MaskFrame(frame, mask, pc.HsvLow(), pc.HsvHigh());
     FindContours(mask, contours);
-    REQUIRE(contours.size() == 0);
+    REQUIRE(contours.empty());
   }
 
   SECTION("tuned hsv range") {


### PR DESCRIPTION
- Suppress recursive function warning
- Don't use const pointer typedef
- Clean up network tables listeners on shutdown
- Initialize all Controller instance vars
