### PR TITLE
Ignore unrecognized NT table entries

### DIFF
--- a/admin/deadeye/models.py
+++ b/admin/deadeye/models.py
@@ -117,7 +117,7 @@ class Camera:
         elif key == "Info":
             self.info = json.loads(value)
         else:
-            current_app.logger.error("unrecognized key: %s", key)
+            pass
 
         Unit.api.refresh_units = True
 


### PR DESCRIPTION
This was spamming a stack trace to the logs.
